### PR TITLE
Normals for polys where first 3 points are in a line

### DIFF
--- a/Geometry3D/geometry/plane.py
+++ b/Geometry3D/geometry/plane.py
@@ -6,6 +6,10 @@ from .line import Line
 from ..utils.solver import solve
 from ..utils.vector import Vector,x_unit_vector,y_unit_vector,z_unit_vector
 from ..utils.constant import *
+
+class InvalidPlane(ValueError):
+    pass
+
 class Plane(GeoBody):
     """
     - Plane(Point, Point, Point):
@@ -63,6 +67,8 @@ class Plane(GeoBody):
             # (the length doesn't matter) so we just use the cross
             # product
             vec = vab.cross(vac)
+            if vec.length() == 0:
+                raise InvalidPlane('%s x %s == 0' % (vab, vac))
             self._init_pn(a, vec)
         elif len(args) == 2:
             self._init_pn(*args)

--- a/Geometry3D/geometry/polygon.py
+++ b/Geometry3D/geometry/polygon.py
@@ -5,12 +5,13 @@ from .point import Point
 from ..utils.vector import Vector
 from .line import Line
 from .segment import Segment
-from .plane import Plane
+from .plane import Plane, InvalidPlane
 from ..utils.constant import *
 from ..utils.vector import x_unit_vector,y_unit_vector
 
 import copy
 import math
+from itertools import combinations
 
 def get_circle_point_list(center,normal,radius,n=10):
     if n <= 2:
@@ -123,10 +124,14 @@ class ConvexPolygon(GeoBody):
         self.points = sorted(set(points),key=points.index)
         if len(points) < 3:
             raise ValueError('Cannot build a polygon with number of points smaller than 3')
+        for triple in combinations(self.points, 3):
+            try:
+                self.plane = Plane(*triple)
+                break
+            except InvalidPlane as ex:
+                pass  # These 3 points lie on the same line; try the next triple.
         if reverse:
-            self.plane = -Plane(self.points[0],self.points[1],self.points[2])
-        else:
-            self.plane = Plane(self.points[0],self.points[1],self.points[2])
+            self.plane = -self.plane
     
         self.center_point = self._get_center_point()
 


### PR DESCRIPTION
When you create an intersection, it seems that sometimes the ConvexPolygons that are created have 3 points along the first side. When that happens, the creation of the normal fails with "float division by zero". This is maybe not the most elegant solution but, since the polygon is convex, there must be another set of 3 points that are not in a line.

I can provide example code that shows the problem, but it doesn't occur every time, so creating a test is difficult.